### PR TITLE
Use build-tools-23.0.3 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,9 @@ jdk:
 android:
   components:
     - android-23
-    - build-tools-23.0.1
+    - build-tools-23.0.3
+    - platform-tools
+    - tools
 
 # as per http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/
 sudo: false


### PR DESCRIPTION
See https://github.com/travis-ci/travis-ci/issues/5891 and https://github.com/travis-ci/travis-ci/issues/5648 regarding the `platform-tools` and `tools` additions.
